### PR TITLE
Moving PropTypes to prop-types package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes as T } from 'react';
+import React, { Component } from 'react';
+import T from 'prop-types'
 
 export default class Pusher extends Component {
   static propTypes = {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "immutable": "^3.8.1",
     "lodash": "^4.13.1",
+    "prop-types": "^15.6.0",
     "react": "^15.1.0"
   },
   "jest": {


### PR DESCRIPTION
React has moved the PropTypes out of the main React package  and into it's own repo called `prop-types`.